### PR TITLE
Normaliza equivalencias de severidad y riesgo

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -44,19 +44,44 @@ except UnicodeDecodeError:
 # Cargar el Excel
 df_xlsx = pd.read_excel(xlsx_file)
 
-# Asegurar que las columnas necesarias existen y tienen el mismo nombre
-# Ajustar los nombres de las columnas para que coincidan con los de los ficheros
-# Se incluyen columnas adicionales para garantizar un cruce más estricto
+# Diccionarios de equivalencias para severidad y riesgo
+severity_map = {
+    "critical": "Crítica",
+    "high": "Alta",
+    "medium": "Media",
+    "low": "Baja",
+}
+risk_map = {
+    "critical": "Crítico",
+    "high": "Alto",
+    "medium": "Medio",
+    "low": "Bajo",
+}
+
+# Normalizar y aplicar equivalencias en columnas de severidad y riesgo
+for df in (df_tsv, df_xlsx):
+    if "Severidad" in df.columns:
+        df["Severidad"] = (
+            df["Severidad"].astype(str).str.lower().str.strip().map(severity_map).fillna(df["Severidad"])
+        )
+    if "Riesgo" in df.columns:
+        df["Riesgo"] = (
+            df["Riesgo"].astype(str).str.lower().str.strip().map(risk_map).fillna(df["Riesgo"])
+        )
+
+# Columnas clave para realizar el cruce
 required_columns = [
     "HostValue",
     "Activo Afectado",
     "Vulnerabilidad",
-    "Severidad",
-    "Descripción",
-    "Propuesta resolución",
-    "Estado",
-    "Plugin Output",
 ]
+
+# Normalizar cadenas en columnas clave
+for col in required_columns:
+    if col in df_tsv.columns:
+        df_tsv[col] = df_tsv[col].astype(str).str.lower().str.strip()
+    if col in df_xlsx.columns:
+        df_xlsx[col] = df_xlsx[col].astype(str).str.lower().str.strip()
 
 # Mostrar columnas de ambos archivos para depuración
 #print(f"Columnas en el TSV: {list(df_tsv.columns)}")


### PR DESCRIPTION
## Summary
- Map severidad and riesgo to Spanish values before merging
- Clean key columns and trim merge keys to stable fields for accurate joins

## Testing
- `python -m py_compile merge.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68933db21e2483319bc8c1e40326f31d