### PR TITLE
Avoid duplicate output columns after merge

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -151,6 +151,7 @@ def main() -> None:
     }
     rename_map = {k: v for k, v in rename_map.items() if k in matches.columns}
     out = matches[list(rename_map)].rename(columns=rename_map)
+    out = out.loc[:, ~out.columns.duplicated()]
     out = out[[c for c in ["Activo Afectado", "Vulnerabilidad", "Descripción"] if c in out.columns]]
     print(out)
 


### PR DESCRIPTION
## Summary
- Remove duplicate column names after renaming merged DataFrame columns

## Testing
- `python merge.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas openpyxl` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68948b3b2e648331b34377c91b1f8afa