### PR TITLE
Combine icon with severity

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -161,7 +161,9 @@ def main() -> None:
         rename_map = {k: v for k, v in rename_map.items() if k in matches.columns}
         out = matches[list(rename_map)].rename(columns=rename_map)
         out = out.loc[:, ~out.columns.duplicated()]
-        out["Icono"] = out["Severidad"].map(PUNTOS)
+        out["Severidad"] = out["Severidad"].apply(
+            lambda s: f"{PUNTOS.get(s, '')} {s}"
+        )
         out = out[
             [
                 c
@@ -170,7 +172,6 @@ def main() -> None:
                     "Severidad",
                     "Vulnerabilidad",
                     "Descripción",
-                    "Icono",
                 ]
                 if c in out.columns
             ]
@@ -187,7 +188,9 @@ def main() -> None:
         [["Activo Afectado", "Severidad", "Vulnerabilidad"]]
     )
     if not resolved.empty:
-        resolved["Icono"] = resolved["Severidad"].map(PUNTOS)
+        resolved["Severidad"] = resolved["Severidad"].apply(
+            lambda s: f"{PUNTOS.get(s, '')} {s}"
+        )
         print("VULNERABILIDADES CORREGIDAS")
         print(resolved)
 
@@ -197,7 +200,9 @@ def main() -> None:
         [["Activo Afectado", "Severidad", "Vulnerabilidad"]]
     )
     if not new.empty:
-        new["Icono"] = new["Severidad"].map(PUNTOS)
+        new["Severidad"] = new["Severidad"].apply(
+            lambda s: f"{PUNTOS.get(s, '')} {s}"
+        )
         print("VULNERABILIDADES NUEVAS")
         print(new)
 


### PR DESCRIPTION
## Summary
- Concatenate severity icon directly into the `Severidad` column for matches and remove the separate `Icono` field
- Apply the same icon-text concatenation to resolved and new vulnerabilities outputs

## Testing
- `python -m py_compile merge.py`
- `python merge.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68949b2c3ab0833187bf71eb0faa59d6