### PR TITLE
Normalize severity before adding icons in main table

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -161,8 +161,11 @@ def main() -> None:
         rename_map = {k: v for k, v in rename_map.items() if k in matches.columns}
         out = matches[list(rename_map)].rename(columns=rename_map)
         out = out.loc[:, ~out.columns.duplicated()]
-        out["Severidad"] = out["Severidad"].apply(
-            lambda s: f"{PUNTOS.get(s, '')} {s}"
+        out["Severidad"] = (
+            out["Severidad"]
+            .str.strip().str.lower()
+            .map(SEVERITY_MAP).fillna(out["Severidad"])
+            .apply(lambda s: f"{PUNTOS.get(s, '')} {s}")
         )
         out = out[
             [


### PR DESCRIPTION
## Summary
- normalize severity values using `SEVERITY_MAP` before applying icons in the main coincidences table

## Testing
- `python merge.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas --quiet` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68959db0f8a4833193e7f7758c90b533