### PR TITLE
Formatea DataFrames sin índice

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -186,7 +186,7 @@ def main() -> None:
         print(
             out.assign(
                 Severidad=lambda df: df["Severidad"].map(format_severity)
-            )
+            ).to_string(index=False)
         )
         print("─" * 160)  # Línea continua separadora inferior
 
@@ -210,7 +210,7 @@ def main() -> None:
         print(
             resolved.assign(
                 Severidad=lambda df: df["Severidad"].map(format_severity)
-            )
+            ).to_string(index=False)
         )
         resolved_path = OUTPUT_DIR / "vulnerabilidades_corregidas.tsv"
         resolved[["Activo Afectado", "Vulnerabilidad", "Severidad"]].to_csv(
@@ -234,7 +234,7 @@ def main() -> None:
         print(
             new.assign(
                 Severidad=lambda df: df["Severidad"].map(format_severity)
-            )
+            ).to_string(index=False)
         )
         new_path = OUTPUT_DIR / "vulnerabilidades_nuevas.tsv"
         new[["Activo Afectado", "Vulnerabilidad", "Severidad"]].to_csv(


### PR DESCRIPTION
## Summary
- Oculta el índice en las impresiones de DataFrames para coincidencias y vulnerabilidades corregidas y nuevas.

## Testing
- `python -m py_compile merge.py`
- `python merge.py` *(falla: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(falla: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6895b16174708331b4c65af54fe46630